### PR TITLE
exclude node modules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 .env
+node_modules/


### PR DESCRIPTION
It's outside of best practice to check in the node_modules directory. Please make this correction.